### PR TITLE
Add Complete Order page and improve order quantity handling

### DIFF
--- a/FE/amsral/src/App.tsx
+++ b/FE/amsral/src/App.tsx
@@ -18,6 +18,7 @@ const CustomersPage = lazy(() => import('./pages/CustomersPage'));
 const OrdersPage = lazy(() => import('./pages/OrdersPage'));
 const OrderRecordsPage = lazy(() => import('./pages/OrderRecordsPage'));
 const WorkFlowPage = lazy(() => import('./pages/WorkFlowPage'));
+const CompleteOrderPage = lazy(() => import('./pages/CompleteOrderPage'));
 const RecordAssignmentsPage = lazy(() => import('./pages/RecordAssignmentsPage'));
 const SystemDataPage = lazy(() => import('./pages/SystemDataPage'));
 const ManagementPage = lazy(() => import('./pages/ManagementPage'));
@@ -93,6 +94,7 @@ function App() {
                   <Route path="orders" element={<OrdersPage />} />
                   <Route path="orders/:orderId/records" element={<OrderRecordsPage />} />
                   <Route path="production" element={<WorkFlowPage />} />
+                  <Route path="complete-order" element={<CompleteOrderPage />} />
                   <Route path="production/record/:recordId" element={<RecordAssignmentsPage />} />
                   <Route path="management" element={<ManagementPage />} />
                   <Route path="management/orders/:orderId" element={<OrderDetailsPage />} />

--- a/FE/amsral/src/components/layout/SideBar.tsx
+++ b/FE/amsral/src/components/layout/SideBar.tsx
@@ -17,6 +17,7 @@ import PersonIcon from '@mui/icons-material/Person';
 import ReceiptIcon from '@mui/icons-material/Receipt';
 import PrintIcon from '@mui/icons-material/Print';
 import AssessmentIcon from '@mui/icons-material/Assessment';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import toast from 'react-hot-toast';
 import colors from '../../styles/colors';
 import { useState, useMemo } from 'react';
@@ -30,6 +31,7 @@ const NAVIGATION: NavigationItem[] = [
     { segment: 'dashboard', title: 'Dashboard', icon: <DashboardIcon /> },
     { segment: 'orders', title: 'Orders', icon: <ShoppingCartIcon /> },
     { segment: 'production', title: 'Production Flow', icon: <SettingsApplicationsIcon /> },
+    { segment: 'complete-order', title: 'Complete Order', icon: <CheckCircleIcon /> },
     { segment: 'management', title: 'Management', icon: <ManageAccountsIcon /> },
     { segment: 'qc', title: 'QC', icon: <AssessmentIcon /> },
     { segment: 'billing', title: 'Billing', icon: <ReceiptIcon /> },

--- a/FE/amsral/src/components/orders/SimpleOrderForm.tsx
+++ b/FE/amsral/src/components/orders/SimpleOrderForm.tsx
@@ -57,7 +57,7 @@ const SimpleOrderForm: React.FC<SimpleOrderFormProps> = ({
                             name="quantity"
                             value={form.quantity}
                             onChange={onChange}
-                            placeholder="Quantity"
+                            placeholder="Quantity (Optional)"
                             min={1}
                             autoFocus
                             className="w-full px-4 py-4 text-lg border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/FE/amsral/src/hooks/useAssignments.ts
+++ b/FE/amsral/src/hooks/useAssignments.ts
@@ -1,0 +1,137 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import recordService from '../services/recordService';
+import toast from 'react-hot-toast';
+
+// Query Keys
+export const assignmentKeys = {
+  all: ['assignments'] as const,
+  list: (filters: { page: number; limit: number; search?: string }) => 
+    [...assignmentKeys.all, 'list', filters] as const,
+  record: (recordId: string) => [...assignmentKeys.all, 'record', recordId] as const,
+};
+
+// Types
+export type AssignmentRow = {
+  id: string;
+  recordId: string;
+  orderId: number;
+  orderRef: string;
+  trackingNumber: string;
+  customerName: string;
+  itemName: string;
+  assignedTo: string;
+  quantity: number;
+  washingMachine: string;
+  dryingMachine: string;
+  status: string;
+  assignedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  complete: boolean;
+};
+
+// Custom hook for fetching all assignments
+export function useAssignments(filters: {
+  page: number;
+  limit: number;
+  search?: string;
+}) {
+  return useQuery<{
+    assignments: AssignmentRow[];
+    pagination: {
+      currentPage: number;
+      totalPages: number;
+      totalRecords: number;
+      limit: number;
+    };
+  }>({
+    queryKey: assignmentKeys.list(filters),
+    queryFn: async () => {
+      const response = await recordService.getAllAssignments({
+        page: filters.page,
+        limit: filters.limit,
+        search: filters.search || undefined
+      });
+
+      if (!response.success) {
+        throw new Error('Failed to fetch assignments');
+      }
+
+      // Transform assignments into AssignmentRow format
+      const assignmentRows: AssignmentRow[] = response.data.assignments.map(assignment => ({
+        id: assignment.id.toString(),
+        recordId: assignment.recordId.toString(),
+        orderId: assignment.orderId,
+        orderRef: `${assignment.orderId}`,
+        trackingNumber: assignment.trackingNumber || 'N/A',
+        customerName: assignment.customerName || 'Unknown Customer',
+        itemName: assignment.item || 'Unknown Item',
+        assignedTo: assignment.assignedTo,
+        quantity: assignment.quantity,
+        washingMachine: assignment.washingMachine,
+        dryingMachine: assignment.dryingMachine,
+        status: assignment.status,
+        assignedAt: assignment.assignedAt,
+        createdAt: assignment.createdAt,
+        updatedAt: assignment.updatedAt,
+        complete: assignment.status === 'completed'
+      }));
+
+      return {
+        assignments: assignmentRows,
+        pagination: response.data.pagination,
+      };
+    },
+    staleTime: 2 * 60 * 1000, // 2 minutes - assignments data changes frequently
+    gcTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+// Mutation hook for updating assignment completion
+export function useUpdateAssignmentCompletion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ 
+      recordId, 
+      assignmentId, 
+      isCompleted, 
+      returnQuantity 
+    }: { 
+      recordId: string; 
+      assignmentId: string; 
+      isCompleted: boolean; 
+      returnQuantity?: number 
+    }) => {
+      const response = await recordService.updateAssignmentCompletion(recordId, assignmentId, isCompleted, returnQuantity);
+      return response;
+    },
+    onSuccess: () => {
+      // Invalidate and refetch assignments data
+      queryClient.invalidateQueries({ queryKey: assignmentKeys.all });
+      toast.success('Assignment status updated successfully');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to update assignment status');
+    },
+  });
+}
+
+// Mutation hook for deleting assignment
+export function useDeleteAssignment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ recordId, assignmentId }: { recordId: string; assignmentId: string }) => {
+      await recordService.deleteAssignment(recordId, assignmentId);
+    },
+    onSuccess: () => {
+      // Invalidate and refetch assignments data
+      queryClient.invalidateQueries({ queryKey: assignmentKeys.all });
+      toast.success('Assignment deleted successfully');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to delete assignment');
+    },
+  });
+}

--- a/FE/amsral/src/hooks/useOrders.ts
+++ b/FE/amsral/src/hooks/useOrders.ts
@@ -29,6 +29,7 @@ export type OrderRow = {
   customerId: string;
   customerName: string;
   itemId?: string;
+  itemName?: string;
   quantity: number;
   gpNo?: string;
   notes: string;
@@ -83,6 +84,7 @@ export function useOrders(filters: {
         customerId: order.customerId,
         customerName: order.customerName,
         itemId: order.itemId || undefined,
+        itemName: order.itemName || undefined,
         quantity: order.quantity,
         notes: order.notes,
         records: order.records.map(record => ({

--- a/FE/amsral/src/pages/CompleteOrderPage.tsx
+++ b/FE/amsral/src/pages/CompleteOrderPage.tsx
@@ -1,0 +1,300 @@
+import React, { useState } from 'react';
+import { Typography, IconButton, Menu, MenuItem, Button } from '@mui/material';
+import { MoreVert, Edit, Delete, Refresh, AssignmentTurnedIn, RadioButtonUnchecked } from '@mui/icons-material';
+import type { GridColDef } from '@mui/x-data-grid';
+import PrimaryTable from '../components/common/PrimaryTable';
+import ConfirmationDialog from '../components/common/ConfirmationDialog';
+import CompletionStatusModal from '../components/modals/CompletionStatusModal';
+import { useAssignments, useUpdateAssignmentCompletion, useDeleteAssignment, type AssignmentRow } from '../hooks/useAssignments';
+import type { MachineAssignment } from '../services/recordService';
+import colors from '../styles/colors';
+import { getStatusColor, getStatusLabel, normalizeStatus } from '../utils/statusUtils';
+import toast from 'react-hot-toast';
+
+const CompleteOrderPage: React.FC = () => {
+    // State management
+    const [page, setPage] = useState(0);
+    const [pageSize, setPageSize] = useState(25);
+    const [searchTerm] = useState('');
+    const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+    const [selectedAssignment, setSelectedAssignment] = useState<AssignmentRow | null>(null);
+    const [confirmDialog, setConfirmDialog] = useState({
+        open: false,
+        title: '',
+        message: '',
+        confirmText: 'Confirm',
+        onConfirm: () => { },
+    });
+    const [completionModal, setCompletionModal] = useState({
+        open: false,
+        assignment: null as AssignmentRow | null,
+    });
+
+    // Data fetching
+    const { data, isLoading, error, refetch } = useAssignments({
+        page: page + 1,
+        limit: pageSize,
+        search: searchTerm || undefined
+    });
+
+    // Mutations
+    const updateCompletionMutation = useUpdateAssignmentCompletion();
+    const deleteMutation = useDeleteAssignment();
+
+    // Handle menu actions
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>, assignment: AssignmentRow) => {
+        setMenuAnchor(event.currentTarget);
+        setSelectedAssignment(assignment);
+    };
+
+    const handleMenuClose = () => {
+        setMenuAnchor(null);
+        setSelectedAssignment(null);
+    };
+
+    const handleEditClick = () => {
+        // For now, just show a toast - edit functionality can be implemented later
+        toast('Edit functionality will be implemented');
+        handleMenuClose();
+    };
+
+    const handleDeleteClick = () => {
+        if (selectedAssignment) {
+            setConfirmDialog({
+                open: true,
+                title: 'Delete Assignment',
+                message: 'Are you sure you want to delete this assignment? This action cannot be undone.',
+                confirmText: 'Delete',
+                onConfirm: () => {
+                    deleteMutation.mutate({
+                        recordId: selectedAssignment.recordId,
+                        assignmentId: selectedAssignment.id
+                    });
+                    setConfirmDialog({ ...confirmDialog, open: false });
+                }
+            });
+        }
+        handleMenuClose();
+    };
+
+
+    // Table columns - matching Machine Assignment table structure
+    const columns: GridColDef[] = [
+        {
+            field: 'trackingNumber',
+            headerName: 'Tracking No',
+            flex: 0.8,
+            minWidth: 100,
+            renderCell: (params) => (
+                <span className="font-mono font-semibold" style={{ color: colors.button.primary }}>
+                    {params.row.trackingNumber || 'N/A'}
+                </span>
+            )
+        },
+        { field: 'assignedTo', headerName: 'Assign To', flex: 1.2, minWidth: 120 },
+        { field: 'quantity', headerName: 'Assigned Qty', flex: 0.8, minWidth: 100, type: 'number' },
+        {
+            field: 'returnQuantity',
+            headerName: 'Return Qty',
+            flex: 0.8,
+            minWidth: 100,
+            type: 'number',
+            renderCell: (params) => (
+                <span style={{
+                    color: (params.value || 0) < params.row.quantity ? '#f57c00' : colors.text.primary,
+                    fontWeight: (params.value || 0) < params.row.quantity ? 600 : 'normal'
+                }}>
+                    {params.value || 0}
+                </span>
+            )
+        },
+        { field: 'washingMachine', headerName: 'WM', flex: 0.5, minWidth: 50 },
+        { field: 'dryingMachine', headerName: 'DM', flex: 0.5, minWidth: 50 },
+        {
+            field: 'assignedAt',
+            headerName: 'Assigned At',
+            flex: 1,
+            minWidth: 120,
+            renderCell: (params) => (
+                <span style={{ color: colors.text.secondary }}>
+                    {new Date(params.value).toLocaleDateString()}
+                </span>
+            )
+        },
+        {
+            field: 'status',
+            headerName: 'Status',
+            flex: 0.8,
+            minWidth: 100,
+            renderCell: (params) => {
+                const normalizedStatus = normalizeStatus(params.value);
+                const statusColor = getStatusColor(normalizedStatus);
+                const statusLabel = getStatusLabel(normalizedStatus);
+
+                return (
+                    <span
+                        className="px-2 py-1 rounded-full text-xs font-semibold"
+                        style={{
+                            backgroundColor: `${statusColor}20`,
+                            color: statusColor,
+                            border: `1px solid ${statusColor}40`
+                        }}
+                    >
+                        {statusLabel}
+                    </span>
+                );
+            }
+        },
+        {
+            field: 'completion',
+            headerName: 'Complete',
+            flex: 0.5,
+            minWidth: 80,
+            sortable: false,
+            renderCell: (params) => (
+                <IconButton
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        setCompletionModal({
+                            open: true,
+                            assignment: params.row
+                        });
+                    }}
+                    size="small"
+                    sx={{
+                        color: params.row.complete ? colors.button.primary : colors.text.secondary
+                    }}
+                    title={params.row.complete ? 'Update completion status' : 'Mark as completed'}
+                >
+                    {params.row.complete ? <AssignmentTurnedIn /> : <RadioButtonUnchecked />}
+                </IconButton>
+            )
+        },
+        {
+            field: 'actions',
+            headerName: 'Actions',
+            flex: 0.3,
+            minWidth: 60,
+            sortable: false,
+            renderCell: (params) => (
+                <IconButton
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        handleMenuOpen(e, params.row);
+                    }}
+                    size="small"
+                    sx={{
+                        color: colors.text.secondary,
+                        padding: '4px'
+                    }}
+                >
+                    <MoreVert fontSize="small" />
+                </IconButton>
+            )
+        }
+    ];
+
+    if (error) {
+        return (
+            <div className="w-full mx-auto px-1 sm:px-3 md:px-4 py-3">
+                <div className="flex flex-col items-center justify-center py-8">
+                    <Typography variant="h6" color="error" className="mb-4">
+                        Failed to load assignments
+                    </Typography>
+                    <Button onClick={() => refetch()} startIcon={<Refresh />}>
+                        Retry
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-full mx-auto px-1 sm:px-3 md:px-4 py-3">
+            <div className="flex flex-col gap-2 sm:gap-3 mb-4">
+                <h2 className="text-xl md:text-2xl font-bold" style={{ color: colors.text.primary }}>
+                    Complete Order
+                </h2>
+                <p className="text-sm sm:text-base" style={{ color: colors.text.secondary }}>
+                    Manage and complete machine assignments
+                </p>
+            </div>
+
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200">
+                <PrimaryTable
+                    columns={columns}
+                    rows={data?.assignments || []}
+                    loading={isLoading}
+                    pagination
+                    paginationMode="server"
+                    paginationModel={{
+                        page: page,
+                        pageSize: pageSize
+                    }}
+                    rowCount={data?.pagination.totalRecords || 0}
+                    pageSizeOptions={[10, 25, 50, 100]}
+                    onPaginationModelChange={(model) => {
+                        setPage(model.page);
+                        setPageSize(model.pageSize);
+                    }}
+                    height="auto"
+                />
+            </div>
+
+            {/* Actions Menu */}
+            <Menu
+                anchorEl={menuAnchor}
+                open={Boolean(menuAnchor)}
+                onClose={handleMenuClose}
+                PaperProps={{
+                    sx: {
+                        minWidth: 150,
+                        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                    }
+                }}
+            >
+                <MenuItem onClick={handleEditClick}>
+                    <Edit fontSize="small" className="mr-2" />
+                    Edit
+                </MenuItem>
+                <MenuItem onClick={handleDeleteClick} sx={{ color: 'error.main' }}>
+                    <Delete fontSize="small" className="mr-2" />
+                    Delete
+                </MenuItem>
+            </Menu>
+
+            {/* Confirmation Dialog */}
+            <ConfirmationDialog
+                open={confirmDialog.open}
+                title={confirmDialog.title}
+                message={confirmDialog.message}
+                confirmText={confirmDialog.confirmText}
+                onConfirm={confirmDialog.onConfirm}
+                onCancel={() => setConfirmDialog({ ...confirmDialog, open: false })}
+            />
+
+            {/* Completion Status Modal */}
+            {completionModal.assignment && (
+                <CompletionStatusModal
+                    open={completionModal.open}
+                    onClose={() => setCompletionModal({ ...completionModal, open: false })}
+                    assignment={completionModal.assignment as unknown as MachineAssignment}
+                    onUpdate={async (_assignmentId, isCompleted, returnQuantity) => {
+                        if (completionModal.assignment) {
+                            updateCompletionMutation.mutate({
+                                recordId: completionModal.assignment.recordId,
+                                assignmentId: completionModal.assignment.id,
+                                isCompleted,
+                                returnQuantity
+                            });
+                        }
+                        setCompletionModal({ ...completionModal, open: false });
+                    }}
+                />
+            )}
+
+        </div>
+    );
+};
+
+export default CompleteOrderPage;

--- a/FE/amsral/src/pages/OrderRecordsPage.tsx
+++ b/FE/amsral/src/pages/OrderRecordsPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { Typography, IconButton, Menu, MenuItem } from '@mui/material';
 import { ArrowBack, MoreVert } from '@mui/icons-material';
 import type { GridColDef } from '@mui/x-data-grid';
@@ -30,6 +30,7 @@ export default function OrderRecordsPage() {
     const { orderId } = useParams<{ orderId: string }>();
     const navigate = useNavigate();
     const { user } = useAuth();
+    const [searchParams] = useSearchParams();
 
     // Local state for UI
     const [showAddForm, setShowAddForm] = useState(false);
@@ -54,6 +55,10 @@ export default function OrderRecordsPage() {
         washType: '',
         processTypes: [],
     });
+
+    // Get remaining quantity from URL parameters
+    const remainingQuantityFromUrl = searchParams.get('remainingQuantity');
+    const defaultQuantity = remainingQuantityFromUrl ? parseInt(remainingQuantityFromUrl) : 0;
 
     // Pagination state (removed unused pagination state)
     const [pageSize, setPageSize] = useState(20); // Default to 20 rows per page
@@ -287,6 +292,29 @@ export default function OrderRecordsPage() {
     const handleMultiSelectChange = (field: string) => (e: { target: { value: string[] } }) => {
         handleRecordChange(field, e.target.value);
     };
+
+    // Set default quantity when form is opened
+    const handleOpenAddForm = () => {
+        setNewRecord({
+            id: '',
+            quantity: defaultQuantity > 0 ? defaultQuantity.toString() : '',
+            washType: '',
+            processTypes: [],
+        });
+        setShowAddForm(true);
+    };
+
+    // Initialize form with default quantity when component mounts
+    useEffect(() => {
+        if (defaultQuantity > 0) {
+            setNewRecord(prev => ({
+                ...prev,
+                quantity: defaultQuantity.toString()
+            }));
+            // Auto-show the form if there's a remaining quantity
+            setShowAddForm(true);
+        }
+    }, [defaultQuantity]);
 
     const getTotalRecordsQuantity = () => {
         return records.reduce((total, record) => total + Number(record.quantity), 0);
@@ -742,7 +770,7 @@ export default function OrderRecordsPage() {
                     <h3 className="text-lg font-semibold">Process Records</h3>
                     {!showAddForm && (
                         <PrimaryButton
-                            onClick={() => setShowAddForm(true)}
+                            onClick={handleOpenAddForm}
                             className="px-4 py-2"
                             style={{ backgroundColor: colors.primary[500], color: colors.text.white }}
                         >

--- a/FE/amsral/src/pages/WorkFlowPage.tsx
+++ b/FE/amsral/src/pages/WorkFlowPage.tsx
@@ -21,7 +21,8 @@ import {
 const recordsColumns: GridColDef[] = [
     { field: 'createdAt', headerName: 'Date', flex: 0.8, minWidth: 110 },
     { field: 'trackingNumber', headerName: 'Tracking No', flex: 0.8, minWidth: 100 },
-    { field: 'item', headerName: 'Item', flex: 1.5, minWidth: 150 },
+    { field: 'item', headerName: 'Item Name', flex: 1.5, minWidth: 150 },
+    { field: 'washType', headerName: 'Wash Type', flex: 1.2, minWidth: 120 },
     {
         field: 'quantity',
         headerName: 'Total Qty',
@@ -39,7 +40,6 @@ const recordsColumns: GridColDef[] = [
             </span>
         )
     },
-    { field: 'washType', headerName: 'Wash Type', flex: 1.2, minWidth: 120 },
     { field: 'processTypes', headerName: 'Processes', flex: 2, minWidth: 200 },
     {
         field: 'status',

--- a/FE/amsral/src/services/orderService.ts
+++ b/FE/amsral/src/services/orderService.ts
@@ -14,7 +14,7 @@ export interface CreateOrderRequest {
   date: string;
   customerId: string;
   itemId: string;
-  quantity: number;
+  quantity?: number; // Made optional
   gpNo?: string;
   notes?: string;
   deliveryDate: string;

--- a/FE/amsral/src/services/recordService.ts
+++ b/FE/amsral/src/services/recordService.ts
@@ -212,6 +212,21 @@ class RecordService {
       throw apiError.response?.data || { success: false, message: 'Failed to fetch assignment statistics' };
     }
   }
+
+  // Get all assignments with pagination
+  async getAllAssignments(params?: {
+    page?: number;
+    limit?: number;
+    search?: string;
+  }): Promise<AssignmentsResponse> {
+    try {
+      const response = await apiClient.get('/assignments', { params });
+      return response.data;
+    } catch (error: unknown) {
+      const apiError = error as { response?: { data?: { success: false; message: string } } };
+      throw apiError.response?.data || { success: false, message: 'Failed to fetch assignments' };
+    }
+  }
 }
 
 export default new RecordService();


### PR DESCRIPTION
Introduces a new Complete Order page for managing and completing machine assignments, including related hooks and service methods. Updates order quantity to be optional throughout the app, adjusts validation and navigation logic, and improves UI feedback for orders with missing or zero quantity. Enhances the Orders and Order Records pages to handle remaining quantities and disables navigation for incomplete orders. Also adds item name display and improves assignment management.